### PR TITLE
Fix "error: ‘cout’ is not a member of ‘std’"

### DIFF
--- a/xmrstak/misc/thdq.hpp
+++ b/xmrstak/misc/thdq.hpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <iostream>
 
 template <typename T>
 class thdq


### PR DESCRIPTION
I tried to compile this code, but got error:

/xmrstak/misc/thdq.hpp:46:4: error: ‘cout’ is not a member of ‘std’
    std::cout << "Error pushing an miner event" << std::endl;
    ^
/xmrstak/misc/thdq.hpp:46:51: error: ‘endl’ is not a member of ‘std’
    std::cout << "Error pushing an miner event" << std::endl;