### PR TITLE
Fix: Could NOT find OpenCL on Ubuntu 16.04

### DIFF
--- a/doc/compile_Linux.md
+++ b/doc/compile_Linux.md
@@ -17,7 +17,7 @@
 ### GNU Compiler
 ```
     # Ubuntu / Debian
-    sudo apt install libmicrohttpd-dev libssl-dev cmake build-essential libhwloc-dev ocl-icd-opencl-devFix
+    sudo apt install libmicrohttpd-dev libssl-dev cmake build-essential libhwloc-dev ocl-icd-opencl-dev
     git clone https://github.com/ipbc-dev/bittube-miner.git
     mkdir bittube-miner/build
     cd bittube-miner/build

--- a/doc/compile_Linux.md
+++ b/doc/compile_Linux.md
@@ -17,7 +17,7 @@
 ### GNU Compiler
 ```
     # Ubuntu / Debian
-    sudo apt install libmicrohttpd-dev libssl-dev cmake build-essential libhwloc-dev
+    sudo apt install libmicrohttpd-dev libssl-dev cmake build-essential libhwloc-dev ocl-icd-opencl-devFix
     git clone https://github.com/ipbc-dev/bittube-miner.git
     mkdir bittube-miner/build
     cd bittube-miner/build


### PR DESCRIPTION
I tried to compile this code on Ubuntu 16.04, but got this error:
"Could NOT find OpenCL (missing: OpenCL_LIBRARY) (found version "2.0")"

I found a solution here:
https://github.com/fireice-uk/xmr-stak-amd/issues/97